### PR TITLE
Type the Statuses and Update Services on Incident Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
 # statuscentral
 > Self hosted status page written in golang!
+
+## Creating an Incident
+First step is to create an incident and describe which services were affected and what those services status is.
+
+### Service Statuses
+* Operational
+* Degraded
+* Partial-outage
+* Outage
+* Scheduled Maintenance
+* Unknown
+
+### Incident Status
+* Investigating
+* Identified
+* Update
+* Monitoring
+* Resolved
+
+### Incident Creation Call
+`POST https://status.rocket.chat/api/v1/incidents`
+
+Request body:
+```json
+{
+	"title": "Slowness Reported Again",
+    "time": "2020-01-22T14:39:24.495623-06:00",
+    "status": "Investigating",
+	"services": [
+		{
+			"name": "Marketplace",
+			"status": "Degraded"
+		}
+	]
+}
+```
+
+Resulting object:
+```json
+{
+  "id": 2,
+  "time": "2020-01-22T14:39:24.495623-06:00",
+  "title": "Slowness Reported Again",
+  "status": "Investigating",
+  "updates": [
+    {
+      "id": 0,
+      "time": "2020-02-25T18:44:35.592427-06:00",
+      "status": "Investigating",
+      "message": "Initial status of Investigating"
+    }
+  ],
+  "updatedAt": "2020-02-25T18:44:35.604079-06:00"
+}
+```
+
+### Incident Update
+`POST https://status.rocket.chat/api/v1/incidents/:id/updates`
+```json
+{
+	"message": "Testing msg",
+	"status": "Identified",
+	"time": "2020-02-25T19:00:22.585515764-05:00",
+    "serivces": [
+        {
+            "name": "Marketplace",
+            "status": "Partial-outage"
+        }
+    ]
+}
+```

--- a/controllers/v1/incidents.go
+++ b/controllers/v1/incidents.go
@@ -58,7 +58,7 @@ func IncidentGetOne(c *gin.Context) {
 	c.JSON(http.StatusOK, incident)
 }
 
-//IncidentCreate creates the service, ensuring the database is correct
+//IncidentCreate creates the incident, ensuring the database is correct
 func IncidentCreate(c *gin.Context) {
 	var incident models.Incident
 
@@ -77,22 +77,6 @@ func IncidentCreate(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, &incident)
-}
-
-//IncidentUpdate updates the service, ensuring the database is correct
-func IncidentUpdate(c *gin.Context) {
-	var incident models.Incident
-
-	if err := c.BindJSON(&incident); err != nil {
-		return
-	}
-
-	if err := core.UpdateIncident(&incident); err != nil {
-		internalErrorHandlerDetailed(c, err)
-		return
-	}
-
-	c.JSON(http.StatusOK, &incident)
 }
 
 //IncidentDelete removes the service, ensuring the database is correct
@@ -148,7 +132,7 @@ func IncidentUpdateCreate(c *gin.Context) {
 		return
 	}
 
-	status, ok := models.IncidentStatuses[strings.ToLower(update.Status)]
+	status, ok := models.IncidentStatuses[strings.ToLower(update.Status.String())]
 	if !ok {
 		badRequestHandlerDetailed(c, errors.New("invalid status value"))
 		return

--- a/core/services.go
+++ b/core/services.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/RocketChat/statuscentral/config"
 	"github.com/RocketChat/statuscentral/models"
@@ -28,7 +27,7 @@ func MostCriticalServiceStatus(services []*models.Service) int {
 	mostCritical := 0
 
 	for _, service := range services {
-		serviceStatus := models.ServiceStatusValues[service.Status]
+		serviceStatus := models.ServiceStatusValues[service.Status.String()]
 		if serviceStatus > mostCritical {
 			mostCritical = serviceStatus
 		}
@@ -64,7 +63,7 @@ func createServicesFromConfig() error {
 	return nil
 }
 
-func updateServiceToStatus(serviceName, status string) error {
+func updateServiceToStatus(serviceName string, status models.ServiceStatus) error {
 	service, err := GetServiceByName(serviceName)
 
 	if err != nil {
@@ -75,7 +74,7 @@ func updateServiceToStatus(serviceName, status string) error {
 		return errors.New("unknown service")
 	}
 
-	val, ok := models.ServiceStatuses[strings.ToLower(status)]
+	val, ok := models.ServiceStatuses[status.ToLower()]
 
 	if !ok {
 		return errors.New("invalid service status")

--- a/models/incident.go
+++ b/models/incident.go
@@ -9,36 +9,40 @@ type Incident struct {
 	ID        int               `json:"id"`
 	Time      time.Time         `json:"time"`
 	Title     string            `json:"title"`
-	Status    string            `json:"status"`
-	Services  []Service         `json:"services,omitempty"`
+	Status    IncidentStatus    `json:"status"`
+	Services  []ServiceUpdate   `json:"services,omitempty"`
 	Updates   []*IncidentUpdate `json:"updates"`
 	UpdatedAt time.Time         `json:"updatedAt"`
 }
 
-//IncidentStatusInvestigating - Investigating Incident
-const IncidentStatusInvestigating = "Investigating"
+//IncidentStatus represents the status of the incident
+type IncidentStatus string
 
-//IncidentStatusIdentified - Identified cause of Incident
-const IncidentStatusIdentified = "Identified"
+func (is IncidentStatus) String() string {
+	return string(is)
+}
 
-//IncidentStatusUpdate - An update to the Incident. Does not update overall incident status
-const IncidentStatusUpdate = "Update"
-
-//IncidentStatusMonitoring - Monitoring typically after a fix applied
-const IncidentStatusMonitoring = "Monitoring"
-
-//IncidentStatusResolved - Resolved the incident
-const IncidentStatusResolved = "Resolved"
-
-//IncidentDefaultStatus is the default status of an incident
-const IncidentDefaultStatus = IncidentStatusInvestigating
+const (
+	//IncidentStatusInvestigating - Investigating Incident
+	IncidentStatusInvestigating IncidentStatus = "Investigating"
+	//IncidentStatusIdentified - Identified cause of Incident
+	IncidentStatusIdentified IncidentStatus = "Identified"
+	//IncidentStatusUpdate - An update to the Incident. Does not update overall incident status
+	IncidentStatusUpdate IncidentStatus = "Update"
+	//IncidentStatusMonitoring - Monitoring typically after a fix applied
+	IncidentStatusMonitoring IncidentStatus = "Monitoring"
+	//IncidentStatusResolved - Resolved the incident
+	IncidentStatusResolved IncidentStatus = "Resolved"
+	//IncidentDefaultStatus is the default status of an incident
+	IncidentDefaultStatus IncidentStatus = IncidentStatusInvestigating
+)
 
 //IncidentStatuses holds all of the valid incident statuses
-var IncidentStatuses = map[string]string{
-	"investigating": "Investigating",
-	"identified":    "Identified",
-	"update":        "Update",
-	"monitoring":    "Monitoring",
-	"resolved":      "Resolved",
+var IncidentStatuses = map[string]IncidentStatus{
+	"investigating": IncidentStatusInvestigating,
+	"identified":    IncidentStatusIdentified,
+	"update":        IncidentStatusUpdate,
+	"monitoring":    IncidentStatusMonitoring,
+	"resolved":      IncidentStatusResolved,
 	"default":       IncidentDefaultStatus,
 }

--- a/models/incidentUpdate.go
+++ b/models/incidentUpdate.go
@@ -6,8 +6,9 @@ import (
 
 //IncidentUpdate holds an update for the incident
 type IncidentUpdate struct {
-	ID      int       `json:"id"`
-	Time    time.Time `json:"time"`
-	Status  string    `json:"status"`
-	Message string    `json:"message"`
+	ID       int             `json:"id"`
+	Time     time.Time       `json:"time"`
+	Status   IncidentStatus  `json:"status"`
+	Message  string          `json:"message"`
+	Services []ServiceUpdate `json:"services,omitempty"`
 }

--- a/models/service.go
+++ b/models/service.go
@@ -7,34 +7,43 @@ import (
 
 //Service holds information about the service
 type Service struct {
-	ID          int       `json:"id"`
-	Name        string    `json:"name"`
-	Status      string    `json:"status"`
-	Description string    `json:"description"`
-	Group       string    `json:"group"`
-	Link        string    `json:"link"`
-	Tags        []string  `json:"tags"`
-	Enabled     bool      `json:"enabled"`
-	UpdatedAt   time.Time `json:"updatedAt"`
+	ID          int           `json:"id"`
+	Name        string        `json:"name"`
+	Status      ServiceStatus `json:"status"`
+	Description string        `json:"description"`
+	Group       string        `json:"group"`
+	Link        string        `json:"link"`
+	Tags        []string      `json:"tags"`
+	Enabled     bool          `json:"enabled"`
+	UpdatedAt   time.Time     `json:"updatedAt"`
 }
 
-//ServiceStatusOperational - Everything is good
-const ServiceStatusOperational = "Operational"
+//ServiceStatus represents the status of a service
+type ServiceStatus string
 
-//ServiceStatusDegraded - Degraded Performance
-const ServiceStatusDegraded = "Degraded"
+func (ss ServiceStatus) String() string {
+	return string(ss)
+}
 
-//ServiceStatusPartialOutage - Partial Outage
-const ServiceStatusPartialOutage = "Partial-outage"
+//ToLower converts the status to lowercase string
+func (ss ServiceStatus) ToLower() string {
+	return strings.ToLower(ss.String())
+}
 
-//ServiceStatusOutage - Outage
-const ServiceStatusOutage = "Outage"
-
-//ServiceStatusScheduledMaintenance - Scheduled Maintenance
-const ServiceStatusScheduledMaintenance = "Scheduled Maintenance"
-
-//ServiceStatusUnknown - Unknown - used when the services were loaded from config
-const ServiceStatusUnknown = "Unknown"
+const (
+	//ServiceStatusOperational - Everything is good
+	ServiceStatusOperational ServiceStatus = "Operational"
+	//ServiceStatusDegraded - Degraded Performance
+	ServiceStatusDegraded ServiceStatus = "Degraded"
+	//ServiceStatusPartialOutage - Partial Outage
+	ServiceStatusPartialOutage ServiceStatus = "Partial-outage"
+	//ServiceStatusOutage - Outage
+	ServiceStatusOutage ServiceStatus = "Outage"
+	//ServiceStatusScheduledMaintenance - Scheduled Maintenance
+	ServiceStatusScheduledMaintenance ServiceStatus = "Scheduled Maintenance"
+	//ServiceStatusUnknown - Unknown - used when the services were loaded from config
+	ServiceStatusUnknown ServiceStatus = "Unknown"
+)
 
 //ServiceStatusValues holds the names to numbers for values of the status
 var ServiceStatusValues = map[string]int{
@@ -47,11 +56,11 @@ var ServiceStatusValues = map[string]int{
 }
 
 //ServiceStatuses holds a map of the lower case service statuses
-var ServiceStatuses = map[string]string{
-	strings.ToLower(ServiceStatusOperational):          ServiceStatusOperational,
-	strings.ToLower(ServiceStatusDegraded):             ServiceStatusDegraded,
-	strings.ToLower(ServiceStatusPartialOutage):        ServiceStatusPartialOutage,
-	strings.ToLower(ServiceStatusOutage):               ServiceStatusOutage,
-	strings.ToLower(ServiceStatusScheduledMaintenance): ServiceStatusScheduledMaintenance,
-	strings.ToLower(ServiceStatusUnknown):              ServiceStatusUnknown,
+var ServiceStatuses = map[string]ServiceStatus{
+	ServiceStatusOperational.ToLower():          ServiceStatusOperational,
+	ServiceStatusDegraded.ToLower():             ServiceStatusDegraded,
+	ServiceStatusPartialOutage.ToLower():        ServiceStatusPartialOutage,
+	ServiceStatusOutage.ToLower():               ServiceStatusOutage,
+	ServiceStatusScheduledMaintenance.ToLower(): ServiceStatusScheduledMaintenance,
+	ServiceStatusUnknown.ToLower():              ServiceStatusUnknown,
 }

--- a/models/serviceUpdate.go
+++ b/models/serviceUpdate.go
@@ -1,0 +1,7 @@
+package models
+
+//ServiceUpdate is for a service update
+type ServiceUpdate struct {
+	Name   string        `json:"name"`
+	Status ServiceStatus `json:"status"`
+}

--- a/store/boltstore/incidents.go
+++ b/store/boltstore/incidents.go
@@ -144,7 +144,10 @@ func (s *boltStore) CreateIncidentUpdate(incidentID int, update *models.Incident
 	}
 
 	update.ID = int(seq)
-	update.Time = time.Now()
+
+	if update.Time.IsZero() {
+		update.Time = time.Now()
+	}
 
 	i.Status = update.Status
 	i.Updates = append(i.Updates, update)


### PR DESCRIPTION
# What? :boat:
* Allows services to be updated whenever the incident is updated
* Fixed internal types for the statuses, we were mixing them when we shouldn't have
* When an incident update has a status of resolved, all services are back to operational
* Added examples of the rest api json structure

# Why? :thinking:
Was not working as it should have been and now it is better 😉 