### PR TITLE
Aggregate by the unique day instead of by just the number of the day

### DIFF
--- a/core/incidents.go
+++ b/core/incidents.go
@@ -323,7 +323,7 @@ func AggregateIncidents(incidents []*models.Incident, showEmptyDays bool) models
 		filteredIncidents := []*models.Incident{}
 
 		for _, incident := range incidents {
-			if incident.Time.Day() == t.Day() {
+			if incident.Time.Year() == t.Year() && incident.Time.Month() == t.Month() && incident.Time.Day() == t.Day() {
 				filteredIncidents = append(filteredIncidents, incident)
 			}
 		}

--- a/core/scheduledMaintenance.go
+++ b/core/scheduledMaintenance.go
@@ -315,9 +315,9 @@ func AggregateScheduledMaintenance(scheduledMaintenance []*models.ScheduledMaint
 
 		filteredScheduledMaintenance := []*models.ScheduledMaintenance{}
 
-		for _, scheduledMainenance := range scheduledMaintenance {
-			if scheduledMainenance.PlannedStart.Day() == t.Day() {
-				filteredScheduledMaintenance = append(filteredScheduledMaintenance, scheduledMainenance)
+		for _, maintenance := range scheduledMaintenance {
+			if maintenance.PlannedStart.Year() == t.Year() && maintenance.PlannedStart.Month() == t.Month() && maintenance.PlannedStart.Day() == t.Day() {
+				filteredScheduledMaintenance = append(filteredScheduledMaintenance, maintenance)
 				count++
 			}
 		}


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

Aggregate by the day specific to the year and month.  Otherwise falsely aggregate incidents that happened on different months or years

# Why? :thinking:
<!--Additional explaination if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:
