### PR TITLE
chore: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,14 +16,14 @@ jobs:
     name: Build And Push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Login to Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKERREGISTRY_USERNAME }}
           password: ${{ secrets.DOCKERREGISTRY_PASSWORD }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3.3.1
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout cloud ops
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ secrets.INTERNAL_REPO }}
           token: ${{ secrets.CI_CLOUD_OPS_PERSONAL_ACCESS_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
           echo "NEW_TAG=$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ env.SOURCE_REPO }}
           path: source-repo


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
This PR replaces mutable tag references with immutable commit SHA pins for all third-party GitHub Actions, as part of a supply chain security hardening effort.

Each workflow file now references the exact commit SHA of the desired action version instead of a floating tag. This guarantees that the same code is always executed regardless of whether the version tag is moved or the action's repository is modified after pinning.

# Why? :thinking:
<!--Additional explaination if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->
[SB-958](https://rocketchat.atlassian.net/browse/SB-958)

# PS :eyes:


[SB-958]: https://rocketchat.atlassian.net/browse/SB-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ