### PR TITLE
chore: apply least privilege permissions to GitHub Actions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -7,14 +7,14 @@ on:
     branches:
       - master
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   build-and-push:
     name: Build And Push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Login to Docker Registry

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -7,9 +7,13 @@ on:
       - main
       - develop
 
+permissions: {}
+
 jobs:
   promote:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       IMAGE_NAME: statuscentral
       REPO_NAME: statuscentral


### PR DESCRIPTION
# What? :boat:
This PR applies the principle of least privilege to `GITHUB_TOKEN` permissions across all GitHub Actions workflows by setting `permissions: {}` globally and explicitly re-granting only the minimum permissions required per job, as part of a supply chain security hardening effort.

Workflows relied on GitHub’s default token scopes, which may grant more access than most jobs actually need. Scoping permissions at the job level reduces the attack surface in the event that a GitHub Action, third-party dependency, or CI component is compromised, helping mitigate the impact of potential supply chain attacks and limiting unnecessary repository access.

This change only affects the permissions granted to the workflow `GITHUB_TOKEN`. Operations authenticated using explicitly configured Personal Access Tokens (PATs) continue to have the scopes assigned to those tokens and are not affected by workflow permissions settings.

## Issue(s)
[SB-975](https://rocketchat.atlassian.net/browse/SB-975)
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

# Why? :thinking:
<!--Additional explaination if needed-->

# Links :earth_americas:
<!--
[Task](https://app.asana.com/0/:board_id:/:task_id:)
-->

# PS :eyes:


[SB-975]: https://rocketchat.atlassian.net/browse/SB-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ