### PR TITLE
Add dockerhub OIDC login

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -15,13 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - name: Login to Docker Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+      - name: OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@96ba694c64860c7209bcd1ede7d698c71564ef78 # v1.2.0
         with:
-          username: ${{ secrets.DOCKERREGISTRY_USERNAME }}
-          password: ${{ secrets.DOCKERREGISTRY_PASSWORD }}
+          connection-id: ${{ secrets.DOCKER_OIDC_ID }}
+      - name: Docker OIDC login
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: rocketchat
+          password: ${{ steps.docker_oidc.outputs.token }}
       - name: Build and push
         uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3.3.1
         with:


### PR DESCRIPTION
Replaces Docker Hub username/password login with OIDC-based login (using `DOCKER_OIDC_ID`), matching https://github.com/RocketChat/airlock/pull/32.